### PR TITLE
Update train_verdict_predictor.py; sentence_transformers not used and…

### DIFF
--- a/src/feverous/baseline/predictor/train_verdict_predictor.py
+++ b/src/feverous/baseline/predictor/train_verdict_predictor.py
@@ -13,7 +13,6 @@ from datetime import datetime
 import jsonlines
 import numpy as np
 import torch
-from sentence_transformers import CrossEncoder
 from sklearn.metrics import accuracy_score, classification_report, precision_recall_fscore_support
 from sklearn.model_selection import KFold, train_test_split
 from tqdm import tqdm


### PR DESCRIPTION
… not in requirements.

Hello, I was using your library, and I had a problem with `from sentence_transformers import CrossEncoder` since sentence_transformers is not specified in the requirements. I think it's safe to remove it because it's not used, just imported, and to avoid installation problems, it's better to remove it as it's not declared in the requirements.